### PR TITLE
fix: snsUserInfo内用户主企业是否达到高级认证级别项应该为bool类型

### DIFF
--- a/response/sns_user_info.go
+++ b/response/sns_user_info.go
@@ -25,5 +25,5 @@ type snsUserInfo struct {
 	Nick                 string `json:"nick"`
 	UnionId              string `json:"unionid"`
 	OpenId               string `json:"openid"`
-	MainOrgAuthHighLevel string `json:"main_org_auth_high_level"`
+	MainOrgAuthHighLevel bool   `json:"main_org_auth_high_level"`
 }


### PR DESCRIPTION
抱歉，之前着急了，改漏了一处，上一个pr测试成功，但是main_org_auth_high_level类型不对，导致没获取到这个字段，这次应该没有问题了