### PR TITLE
添加钉钉新版本根据离职时间范围查询离职用户接口 #96

### DIFF
--- a/api_hrm.go
+++ b/api_hrm.go
@@ -18,6 +18,8 @@ package dingtalk
 
 import (
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/zhaoyunxing92/dingtalk/v2/constant"
 	"github.com/zhaoyunxing92/dingtalk/v2/constant/employee"
@@ -43,6 +45,16 @@ func (ding DingTalk) GetHrmToBeHiredEmployee(offset, size int) (res response.Get
 func (ding DingTalk) GetHrmResignEmployeeIds(offset, size int) (res response.GetHrmEmployee, err error) {
 	req := request.NewGetHrmToBeHiredEmployee(offset, size)
 	return res, ding.Request(http.MethodPost, constant.GetHrmResignEmployeeKey, nil, req, &res)
+}
+
+// GetHrmResignEmployeeIds 获取时间范围内离职员工记录
+func (ding DingTalk) GetHrmEmpLeaveRecords(startTime string, endTime string, nextToken string, maxResults int) (res response.GetHrmEmployeeLevelRecord, err error) {
+	u := url.Values{}
+	u.Add("startTime", startTime)
+	u.Add("endTime", endTime)
+	u.Add("nextToken", nextToken)
+	u.Add("maxResults", strconv.Itoa(maxResults))
+	return res, ding.Request(http.MethodGet, constant.GetHrmEmpLeaveRecordsKey, u, nil, &res)
 }
 
 // GetHrmResignEmployee 获取员工离职信息

--- a/constant/api_const.go
+++ b/constant/api_const.go
@@ -162,6 +162,7 @@ const (
 	GetHrmResignEmployeeKey     = "/topapi/smartwork/hrm/employee/querydimission" // 获取离职员工列表
 	GetHrmResignEmployeeInfoKey = "/topapi/smartwork/hrm/employee/listdimission"  // 获取员工离职信息
 	HrmCreateEmployeeKey        = "/topapi/smartwork/hrm/employee/addpreentry"    // 添加企业待入职员工
+	GetHrmEmpLeaveRecordsKey    = "/v1.0/contact/empLeaveRecords"                 // 获取时间范围内离职员工记录
 
 	GetHrmFieldKey            = "/topapi/smartwork/hrm/employee/field/grouplist" // 获取花名册字段组详情
 	GetHrmEmployeeFieldKey    = "/topapi/smartwork/hrm/employee/v2/list"         // 获取员工花名册字段信息

--- a/request/user_access_token.go
+++ b/request/user_access_token.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 zhaoyunxing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package request
 
 const (

--- a/response/contact_user.go
+++ b/response/contact_user.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 zhaoyunxing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package response
 
 type ContactUser struct {

--- a/response/get_hrm_employee_leve_record.go
+++ b/response/get_hrm_employee_leve_record.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 zhaoyunxing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package response
+
+type GetHrmEmployeeLevelRecord struct {
+	Response
+
+	// 离职记录列表。
+	Records []employeeField `json:"records"`
+
+	// 分页游标，首次查询，该参数传0；非首次查询，该参数传上次调用本接口返回的nextToken。
+	NextToken string `json:"nextToken"`
+}
+
+type employeeField struct {
+
+	// 员工的userId
+	UserId string `json:"userId"`
+
+	// 员工名字。
+
+	Name string `json:"name"`
+
+	// 员工的userId
+	StateCode string `json:"stateCode"`
+
+	// 手机号码
+	Mobile string `json:"mobile"`
+
+	// 离职时间 YYYY-MM-DDTHH:mm:ssZ（ISO 8601/RFC 3339）
+	LeaveTime string `json:"leaveTime"`
+
+	// 退出企业方式，取值：oapi：调用接口删除；cancel：注销；leave：主动离职；unknown：未知原因；delete：管理员删除
+	LeaveReason string `json:"leaveReason"`
+}

--- a/response/user_access_token.go
+++ b/response/user_access_token.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 zhaoyunxing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package response
 
 import "github.com/pkg/errors"


### PR DESCRIPTION
[因原接口获取离职用户是查了全部数据，数据处理量较大，咨询了钉钉工单有这个新接口可以提供按时间范围对接。 GOLANG不熟悉，请多审核](https://github.com/zhaoyunxing92/dingtalk/pull/96)
添加license